### PR TITLE
[codex] Add SSH integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ cython_debug/
 
 # config files
 *.ini 
+
+# Local deployment artifacts and provider-specific secrets
+SSH/DEPLOY/

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Once the server is running (this can take a few seconds), access it on the confi
 
     ssh guest@localhost -p 8022
 
+## Running Automated Tests
+After installing the Python dependencies, run the integration tests from the repository root:
+
+    python3 -m unittest discover -s tests
+
+The integration tests start the real SSH server on a local random port, connect with an SSH client, and use a deterministic fake LLM backend so assertions do not depend on live model output.
+
 ### Logging
 Logs will be written to the file specified in the `log_file` configuration option. By default, this is `SSH/ssh_log.log`. 
 

--- a/SSH/config.ini.TEMPLATE
+++ b/SSH/config.ini.TEMPLATE
@@ -88,7 +88,7 @@ system_prompt = Interpret all inputs as though they were SSH commands and provid
     standard. Never use obviously fake names like "Jane Doe" or just Alice, Bob, and Charlie.
 
     If at any time the user's input would cause the SSH session to close (e.g., if 
-    they exited the login shell), your only answer should be "XXX-END-OF-SESSION-XXX" 
+    they exited the login shell), your only answer should be "YYY-END-OF-SESSION-YYY"
     with no additional output before or after. Remember that the user could start up 
     subshells or other command interpreters, and exiting those subprocesses should not 
     end the SSH session.
@@ -105,5 +105,3 @@ guest =
 user1 = secretpw
 user2 = password123
 root = *
-
-

--- a/SSH/ssh_server.py
+++ b/SSH/ssh_server.py
@@ -27,6 +27,13 @@ from langchain_core.runnables import RunnablePassthrough
 from asyncssh.misc import ConnectionLost
 import socket
 
+config = ConfigParser()
+accounts = {}
+llm_sessions = {}
+thread_local = threading.local()
+logger = logging.getLogger(__name__)
+with_message_history = None
+
 class JSONFormatter(logging.Formatter):
     def __init__(self, sensor_name, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -183,6 +190,9 @@ async def handle_client(process: asyncssh.SSHServerProcess, server: MySSHServer)
     # This is the main loop for handling SSH client connections. 
     # Any user interaction should be done here.
 
+    if with_message_history is None:
+        raise RuntimeError("LLM message history is not configured.")
+
     # Give each session a unique name
     task_uuid = f"session-{uuid.uuid4()}"
     current_task = asyncio.current_task()
@@ -251,12 +261,9 @@ async def handle_client(process: asyncssh.SSHServerProcess, server: MySSHServer)
     # Just in case we ever get here, which we probably shouldn't
     # process.exit(0)
 
-async def start_server() -> None:
-    async def process_factory(process: asyncssh.SSHServerProcess) -> None:
-        server = process.get_server()
-        await handle_client(process, server)
-
-    await asyncssh.listen(
+async def start_server():
+    return await asyncssh.listen(
+        host=config['ssh'].get("listen_host", ""),
         port=config['ssh'].getint("port", 8022),
         reuse_address=True,
         reuse_port=True,
@@ -371,10 +378,7 @@ def get_prompts(prompt: Optional[str], prompt_file: Optional[str]) -> dict:
         "user_prompt": user_prompt
     }
 
-#### MAIN ####
-
-try:
-    # Parse command line arguments
+def parse_args(argv=None):
     parser = argparse.ArgumentParser(description='Start the SSH honeypot server.')
     parser.add_argument('-c', '--config', type=str, default=None, help='Path to the configuration file')
     parser.add_argument('-p', '--prompt', type=str, help='The entire text of the prompt')
@@ -390,28 +394,30 @@ try:
     parser.add_argument('-L', '--log-file', type=str, help='The name of the file you wish to write the honeypot log to')
     parser.add_argument('-S', '--sensor-name', type=str, help='The name of the sensor, used to identify this honeypot in the logs')
     parser.add_argument('-u', '--user-account', action='append', help='User account in the form username=password. Can be repeated.')
-    args = parser.parse_args()
+    return parser.parse_args(argv)
 
-    # Determine which config file to load
-    config = ConfigParser()
+
+def load_config(args) -> ConfigParser:
+    loaded_config = ConfigParser()
     if args.config is not None:
-        # User explicitly set a config file; error if it doesn't exist.
         if not os.path.exists(args.config):
             print(f"Error: The specified config file '{args.config}' does not exist.", file=sys.stderr)
             sys.exit(1)
-        config.read(args.config)
+        loaded_config.read(args.config)
     else:
         default_config = "config.ini"
         if os.path.exists(default_config):
-            config.read(default_config)
+            loaded_config.read(default_config)
         else:
-            # Use defaults when no config file found.
-            config['honeypot'] = {'log_file': 'ssh_log.log', 'sensor_name': socket.gethostname()}
-            config['ssh'] = {'port': '8022', 'host_priv_key': 'ssh_host_key', 'server_version_string': 'SSH-2.0-OpenSSH_8.2p1 Ubuntu-4ubuntu0.3'}
-            config['llm'] = {'llm_provider': 'openai', 'model_name': 'gpt-3.5-turbo', 'trimmer_max_tokens': '64000', 'temperature': '0.7', 'system_prompt': ''}
-            config['user_accounts'] = {}
+            loaded_config['honeypot'] = {'log_file': 'ssh_log.log', 'sensor_name': socket.gethostname()}
+            loaded_config['ssh'] = {'port': '8022', 'host_priv_key': 'ssh_host_key', 'server_version_string': 'SSH-2.0-OpenSSH_8.2p1 Ubuntu-4ubuntu0.3'}
+            loaded_config['llm'] = {'llm_provider': 'openai', 'model_name': 'gpt-3.5-turbo', 'trimmer_max_tokens': '64000', 'temperature': '0.7', 'system_prompt': ''}
+            loaded_config['user_accounts'] = {}
 
-    # Override config values with command line arguments if provided
+    return loaded_config
+
+
+def apply_args_to_config(args) -> None:
     if args.llm_provider:
         config['llm']['llm_provider'] = args.llm_provider
     if args.model_name:
@@ -422,7 +428,7 @@ try:
         config['llm']['system_prompt'] = args.system_prompt
     if args.temperature is not None:
         config['llm']['temperature'] = str(args.temperature)
-    if args.port:
+    if args.port is not None:
         config['ssh']['port'] = str(args.port)
     if args.host_priv_key:
         config['ssh']['host_priv_key'] = args.host_priv_key
@@ -433,7 +439,6 @@ try:
     if args.sensor_name:
         config['honeypot']['sensor_name'] = args.sensor_name
 
-    # Merge command-line user accounts into the config
     if args.user_account:
         if 'user_accounts' not in config:
             config['user_accounts'] = {}
@@ -444,36 +449,27 @@ try:
             else:
                 config['user_accounts'][account.strip()] = ''
 
-    # Read the user accounts from the configuration
-    accounts = get_user_accounts()
 
-    # Always use UTC for logging
-    logging.Formatter.formatTime = (lambda self, record, datefmt=None: datetime.datetime.fromtimestamp(record.created, datetime.timezone.utc).isoformat(sep="T",timespec="milliseconds"))
+def configure_logging() -> None:
+    global logger
 
-    # Get the sensor name from the config or use the system's hostname
+    logging.Formatter.formatTime = (lambda self, record, datefmt=None: datetime.datetime.fromtimestamp(record.created, datetime.timezone.utc).isoformat(sep="T", timespec="milliseconds"))
+
     sensor_name = config['honeypot'].get('sensor_name', socket.gethostname())
-
-    # Set up the honeypot logger
-    logger = logging.getLogger(__name__)  
-    logger.setLevel(logging.INFO)  
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+    logger.handlers.clear()
+    logger.filters.clear()
+    logger.propagate = False
 
     log_file_handler = logging.FileHandler(config['honeypot'].get("log_file", "ssh_log.log"))
-    logger.addHandler(log_file_handler)
-
     log_file_handler.setFormatter(JSONFormatter(sensor_name))
+    logger.addHandler(log_file_handler)
+    logger.addFilter(ContextFilter())
 
-    f = ContextFilter()
-    logger.addFilter(f)
 
-    # Now get access to the LLM
-
-    prompts = get_prompts(args.prompt, args.prompt_file)
-    llm_system_prompt = prompts["system_prompt"]
-    llm_user_prompt = prompts["user_prompt"]
-
+def build_message_history(llm_system_prompt: str, llm_user_prompt: str):
     llm = choose_llm(config['llm'].get("llm_provider"), config['llm'].get("model_name"))
-
-    llm_sessions = dict()
 
     llm_trimmer = trim_messages(
         max_tokens=config['llm'].getint("trimmer_max_tokens", 64000),
@@ -504,22 +500,47 @@ try:
         | llm
     )
 
-    with_message_history = RunnableWithMessageHistory(
-        llm_chain, 
+    return RunnableWithMessageHistory(
+        llm_chain,
         llm_get_session_history,
         input_messages_key="messages"
     )
-    # Thread-local storage for connection details
+
+
+def configure_runtime(args, message_history=None) -> None:
+    global accounts, config, llm_sessions, thread_local, with_message_history
+
+    config = load_config(args)
+    apply_args_to_config(args)
+
+    accounts = get_user_accounts()
+    llm_sessions = {}
     thread_local = threading.local()
+    configure_logging()
 
-    # Kick off the server!
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    loop.run_until_complete(start_server())
-    loop.run_forever()
+    if message_history is None:
+        prompts = get_prompts(args.prompt, args.prompt_file)
+        with_message_history = build_message_history(prompts["system_prompt"], prompts["user_prompt"])
+    else:
+        with_message_history = message_history
 
-except Exception as e:
-    print(f"Error: {e}", file=sys.stderr)
-    traceback.print_exc()
-    sys.exit(1)
 
+def main(argv=None) -> int:
+    try:
+        args = parse_args(argv)
+        configure_runtime(args)
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(start_server())
+        loop.run_forever()
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        traceback.print_exc()
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,4 +1,8 @@
 * Branch out to other protocols, such as SMTP or HTTP (REST API?)
+* P0: Replace thread-local connection metadata with per-session state or contextvars so concurrent SSH sessions cannot be logged with the wrong source/destination IP and port.
+* P1: Add bounded resource controls for public SSH input: maximum line length, session timeout, connection/request limits, LLM call throttling, and cleanup for per-session message history.
+* P3: Clean up the SSH server lifecycle code. Remove the unused local process_factory, stop constructing a separate MySSHServer in the asyncssh process_factory, and make session summary ownership explicit.
+* P3: Refactor ssh_server.py so import has no side effects and core setup lives behind main()/smaller helpers. This should make config loading, auth behavior, logging, and LLM/session handling easier to test.
 * Sometimes the LLM hallucinates the user's future inputs, and acts as though the user typed them. The prompt section below tries to fix this, but doesn't seem to work well.  
         Never include your guess at the next user command(s) in your output. Be sure to only emulate one input at a time, and to never anticipate what the user's next input will be. For each user input, only send the expected output and nothing else. For example, in the following Python interpreter snippet, the user typed 'exti', but the LLM incrorrectly responded with 'exit' and then simulated exiting the Python shell.  Do not do things like this.
         guest@devserver:~$ python

--- a/tests/test_ssh_integration.py
+++ b/tests/test_ssh_integration.py
@@ -1,0 +1,206 @@
+import asyncio
+from base64 import b64decode
+from configparser import ConfigParser
+import json
+from pathlib import Path
+import sys
+import tempfile
+import threading
+import unittest
+
+import asyncssh
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SSH_DIR = REPO_ROOT / "SSH"
+sys.path.insert(0, str(SSH_DIR))
+
+import ssh_server  # noqa: E402
+
+
+PROMPT = "guest@deceive-test:~$ "
+
+
+class FakeLLMResponse:
+    def __init__(self, content: str):
+        self.content = content
+
+
+class ScriptedMessageHistory:
+    async def ainvoke(self, payload, config=None):
+        message = payload["messages"][-1].content
+        username = payload["username"]
+        interactive = payload["interactive"]
+
+        if "Examine the list of all the SSH commands" in message:
+            return FakeLLMResponse("The user ran a simple test command.\n\nJudgement: BENIGN")
+        if message == "":
+            return FakeLLMResponse(f"Welcome to deceive-test\n{PROMPT}")
+        if message == "exit":
+            return FakeLLMResponse("YYY-END-OF-SESSION-YYY")
+        if message == "pwd":
+            if interactive:
+                return FakeLLMResponse(f"/home/{username}\n{PROMPT}")
+            return FakeLLMResponse(f"/home/{username}\n")
+
+        suffix = PROMPT if interactive else ""
+        return FakeLLMResponse(f"ran {message}\n{suffix}")
+
+
+class SSHIntegrationTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        loop = asyncio.get_running_loop()
+        loop.set_debug(False)
+        loop.slow_callback_duration = 10
+
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.work_dir = Path(self.temp_dir.name)
+        self.host_key = self.work_dir / "ssh_host_key"
+        self.log_file = self.work_dir / "ssh_log.log"
+
+        key = asyncssh.generate_private_key("ssh-rsa")
+        key.write_private_key(str(self.host_key))
+
+        ssh_server.config = ConfigParser()
+        ssh_server.config["honeypot"] = {
+            "log_file": str(self.log_file),
+            "sensor_name": "integration-test",
+        }
+        ssh_server.config["ssh"] = {
+            "listen_host": "127.0.0.1",
+            "port": "0",
+            "host_priv_key": str(self.host_key),
+            "server_version_string": "OpenSSH_8.2p1 Ubuntu-4ubuntu0.3",
+        }
+        ssh_server.config["llm"] = {
+            "llm_provider": "fake",
+            "model_name": "fake",
+            "trimmer_max_tokens": "64000",
+            "temperature": "0.0",
+            "system_prompt": "",
+        }
+        ssh_server.config["user_accounts"] = {
+            "guest": "",
+            "user1": "secretpw",
+            "root": "*",
+        }
+        ssh_server.accounts = ssh_server.get_user_accounts()
+        ssh_server.llm_sessions = {}
+        ssh_server.thread_local = threading.local()
+        ssh_server.with_message_history = ScriptedMessageHistory()
+        ssh_server.configure_logging()
+
+        self.server = await ssh_server.start_server()
+        self.port = self.server.get_port()
+
+    async def asyncTearDown(self):
+        self.server.close()
+        await self.server.wait_closed()
+        for handler in ssh_server.logger.handlers:
+            handler.flush()
+            handler.close()
+        ssh_server.logger.handlers.clear()
+        ssh_server.logger.filters.clear()
+
+    async def connect(self, username="guest", password=None):
+        return await asyncssh.connect(
+            "127.0.0.1",
+            port=self.port,
+            username=username,
+            password=password,
+            known_hosts=None,
+        )
+
+    def read_log_records(self):
+        for handler in ssh_server.logger.handlers:
+            handler.flush()
+        return [
+            json.loads(line)
+            for line in self.log_file.read_text().splitlines()
+            if line.strip()
+        ]
+
+    async def test_non_interactive_command_runs_through_real_ssh_server(self):
+        async with await self.connect() as conn:
+            result = await conn.run("pwd", check=True)
+
+        self.assertEqual(result.stdout, "/home/guest\n")
+        records = self.read_log_records()
+        messages = [record["message"] for record in records]
+        self.assertIn("SSH connection received", messages)
+        self.assertIn("User input", messages)
+        self.assertIn("LLM response", messages)
+        self.assertIn("Session summary", messages)
+
+        user_input = next(record for record in records if record["message"] == "User input")
+        self.assertFalse(user_input["interactive"])
+        self.assertEqual(b64decode(user_input["details"]).decode("utf-8"), "pwd")
+
+        summary = next(record for record in records if record["message"] == "Session summary")
+        self.assertEqual(summary["judgement"], "BENIGN")
+
+    async def test_interactive_session_runs_commands_and_exits(self):
+        async with await self.connect() as conn:
+            process = await conn.create_process(term_type="xterm")
+            banner = await asyncio.wait_for(process.stdout.readuntil(PROMPT), timeout=2)
+            self.assertIn("Welcome to deceive-test", banner)
+
+            process.stdin.write("pwd\n")
+            output = await asyncio.wait_for(process.stdout.readuntil(PROMPT), timeout=2)
+            self.assertIn("/home/guest", output)
+
+            process.stdin.write("exit\n")
+            await asyncio.wait_for(process.wait(), timeout=2)
+
+        records = self.read_log_records()
+        interactive_inputs = [
+            record for record in records
+            if record["message"] == "User input" and record["interactive"]
+        ]
+        self.assertEqual(
+            [b64decode(record["details"]).decode("utf-8") for record in interactive_inputs],
+            ["pwd", "exit"],
+        )
+
+    async def test_password_and_wildcard_accounts_can_authenticate(self):
+        async with await self.connect(username="user1", password="secretpw") as conn:
+            result = await conn.run("pwd", check=True)
+        self.assertEqual(result.stdout, "/home/user1\n")
+
+        async with await self.connect(username="root", password="anything") as conn:
+            result = await conn.run("pwd", check=True)
+        self.assertEqual(result.stdout, "/home/root\n")
+
+    async def test_wrong_password_is_rejected(self):
+        with self.assertRaises(asyncssh.PermissionDenied):
+            async with await self.connect(username="user1", password="wrong"):
+                pass
+
+    @unittest.expectedFailure
+    async def test_concurrent_connections_keep_log_source_ports_separate(self):
+        # Known P0 bug: connection metadata is thread-local even though sessions
+        # share one asyncio thread, so overlapping sessions can inherit each
+        # other's source port in later log records.
+        first = await self.connect()
+        second = await self.connect()
+        try:
+            first_port = first.get_extra_info("sockname")[1]
+            await first.run("first", check=True)
+        finally:
+            first.close()
+            second.close()
+            await first.wait_closed()
+            await second.wait_closed()
+
+        records = self.read_log_records()
+        first_input = next(
+            record for record in records
+            if record["message"] == "User input"
+            and b64decode(record["details"]).decode("utf-8") == "first"
+        )
+        self.assertEqual(first_input["src_port"], first_port)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Refactor the SSH server runtime setup so it can be imported and started from tests without immediately running the foreground server loop.
- Add full SSH integration tests that start the real AsyncSSH server on a local random port, connect with an AsyncSSH client, and exercise non-interactive commands, interactive commands, authentication, logging, and the known concurrent-attribution bug as an expected failure.
- Apply follow-up cleanup items: ignore local deployment artifacts, fix the template end-of-session sentinel, and record TODOs for resource limits and lifecycle cleanup.

## Validation

- python3 -m py_compile SSH/ssh_server.py tests/test_ssh_integration.py
- git diff --check
- uv run --with asyncssh --with langchain-openai --with langchain-aws --with langchain-google-genai --with langchain-ollama --with langchain-core python -m unittest discover -s tests -> Ran 5 tests, OK (expected failures=1)