### PR TITLE
[codex] Add pytest CI workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,41 @@
+name: Pytest
+
+on:
+  pull_request:
+    branches: [main, dev]
+  push:
+    branches: [main, dev]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pytest-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Pytest / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Install dependencies
+        run: uv sync --frozen --python ${{ matrix.python-version }}
+
+      - name: Run tests
+        run: uv run --frozen pytest


### PR DESCRIPTION
## Summary

Adds the first GitHub Actions workflow for DECEIVE test automation.

The workflow runs pytest for pull requests targeting `main` or `dev`, and for pushes to `main` or `dev`. It validates Python 3.11, 3.12, and 3.13 using uv with frozen dependencies.

## Validation

- `uv run pytest`
- `uv run --frozen pytest`

## Notes

After this lands and runs once, configure branch protection/rulesets for `dev` and `main` to require the matrix checks:

- `Pytest / Python 3.11`
- `Pytest / Python 3.12`
- `Pytest / Python 3.13`